### PR TITLE
fix: 修复托盘图标显示和事件同步问题

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "默认权限配置，允许所有窗口访问核心功能和事件系统",
+  "windows": ["*"],
+  "permissions": [
+    "core:default",
+    "core:event:default",
+    "core:event:allow-listen",
+    "core:event:allow-emit",
+    "core:event:allow-emit-to",
+    "core:window:default",
+    "core:window:allow-show",
+    "core:window:allow-hide",
+    "core:window:allow-close",
+    "core:window:allow-set-focus",
+    "core:window:allow-center",
+    "core:window:allow-minimize",
+    "core:window:allow-unminimize",
+    "core:app:default",
+    "core:app:allow-app-show",
+    "core:app:allow-app-hide"
+  ]
+}
+

--- a/src-tauri/gen/schemas/capabilities.json
+++ b/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{}
+{"default":{"identifier":"default","description":"默认权限配置，允许所有窗口访问核心功能和事件系统","local":true,"windows":["*"],"permissions":["core:default","core:event:default","core:event:allow-listen","core:event:allow-emit","core:event:allow-emit-to","core:window:default","core:window:allow-show","core:window:allow-hide","core:window:allow-close","core:window:allow-set-focus","core:window:allow-center","core:window:allow-minimize","core:window:allow-unminimize","core:app:default","core:app:allow-app-show","core:app:allow-app-hide"]}}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -143,11 +143,11 @@ pub async fn switch_provider(
         }
     }
 
-    // 发射事件到前端
+    // 发射事件到前端（明确发送到主窗口）
     let event_data = serde_json::json!({
         "providerId": provider_id
     });
-    if let Err(e) = app.emit("provider-switched", event_data) {
+    if let Err(e) = app.emit_to("main", "provider-switched", event_data) {
         log::error!("发射供应商切换事件失败: {}", e);
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,11 +47,6 @@
     ],
     "security": {
       "csp": "default-src 'self' 'unsafe-inline' data: blob: https://api.github.com https://github.com"
-    },
-    "trayIcon": {
-      "iconPath": "icons/icon.png",
-      "iconAsTemplate": true,
-      "menuOnLeftClick": false
     }
   },
   "bundle": {


### PR DESCRIPTION
## 🐛 问题描述

修复了以下关键问题：

1. **托盘图标显示问题**
   - 修复托盘出现双图标的问题
   - 修复图标不显示的问题
   - 修复右键无响应的问题

2. **事件同步问题**
   - 修复通过托盘切换 provider 后主窗口不同步的问题
   - 统一事件发射机制

3. **权限配置问题**
   - 修复 `event.listen not allowed` 权限错误
   - 添加 Tauri 2.x capabilities 配置

## 🔧 技术方案

### 1. 托盘图标修复
- 移除 `tauri.conf.json` 中的静态 trayIcon 配置
- 使用完全动态的 `TrayIconBuilder` 配置
- 通过 `.icon(app.default_window_icon().unwrap().clone())` 设置图标

### 2. 事件同步修复
- 统一使用 `app.emit_to("main", "provider-switched", ...)` 发射事件
- 移除重复的事件发射逻辑
- 简化 `switch_provider_internal` 函数，避免重复代码

### 3. 权限配置
- 创建 `src-tauri/capabilities/default.json`
- 添加必要的事件监听权限：
  - `core:event:allow-listen`
  - `core:event:allow-emit`
  - `core:event:allow-emit-to`

## 📝 改动文件

- `src-tauri/capabilities/default.json` (新建)
- `src-tauri/src/commands.rs`
- `src-tauri/src/lib.rs`
- `src-tauri/tauri.conf.json`
- `src-tauri/gen/schemas/capabilities.json` (自动生成)

## ✅ 测试验证

- [x] 托盘图标正常显示
- [x] 左键点击显示菜单
- [x] 从托盘切换 provider，主窗口同步更新
- [x] 无权限错误
- [x] 编译无警告（除未使用的 MenuBarManager）

## 🔗 相关 Issue

修复了用户报告的托盘图标和事件同步问题。