### PR TITLE
fix: improve dark mode text color contrast and accessibility

### DIFF
--- a/src/components/MainWindow/ClaudeConfigModal.tsx
+++ b/src/components/MainWindow/ClaudeConfigModal.tsx
@@ -81,7 +81,7 @@ function ClaudeConfigModal({ isOpen, onClose }: ClaudeConfigModalProps) {
         {isLoading ? (
           <div className="p-8 text-center">
             <div className="w-8 h-8 border-4 border-main border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-            <p>加载配置信息中...</p>
+            <p className="text-foreground">加载配置信息中...</p>
           </div>
         ) : (
           <div className="space-y-6">
@@ -93,7 +93,7 @@ function ClaudeConfigModal({ isOpen, onClose }: ClaudeConfigModalProps) {
               <CardContent>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-foreground/70">配置文件存在：</span>
+                    <span className="text-foreground">配置文件存在:</span>
                     <Badge
                       variant={configData?.exists ? "default" : "destructive"}
                     >
@@ -101,9 +101,9 @@ function ClaudeConfigModal({ isOpen, onClose }: ClaudeConfigModalProps) {
                     </Badge>
                   </div>
                   <div className="space-y-2">
-                    <span className="text-foreground/70">配置路径：</span>
+                    <span className="text-foreground">配置路径:</span>
                     <div className="flex items-center gap-2">
-                      <span className="text-sm font-mono text-foreground/80 flex-1 truncate">
+                      <span className="text-sm font-mono text-foreground flex-1 truncate">
                         {configData?.path}
                       </span>
                       <Button
@@ -158,7 +158,7 @@ function ClaudeConfigModal({ isOpen, onClose }: ClaudeConfigModalProps) {
                 </CardHeader>
                 <CardContent>
                   <div className="bg-secondary-background border-2 border-border rounded-base p-4 max-h-96 overflow-auto">
-                    <pre className="text-sm font-mono text-foreground/80 whitespace-pre-wrap break-all">
+                    <pre className="text-sm font-mono text-foreground whitespace-pre-wrap break-all">
                       {JSON.stringify(configData.content, null, 2)}
                     </pre>
                   </div>
@@ -167,14 +167,14 @@ function ClaudeConfigModal({ isOpen, onClose }: ClaudeConfigModalProps) {
             ) : (
               <Card>
                 <CardContent className="text-center py-8">
-                  <div className="text-foreground/40 mb-4">
+                  <div className="text-foreground opacity-40 mb-4">
                     <Eye size={48} className="mx-auto" />
                   </div>
                   <h3 className="text-lg font-heading text-foreground mb-2">
                     配置文件不存在
                   </h3>
-                  <p className="text-foreground/60">
-                    Claude Code 配置文件未找到，请确保已正确安装并配置 Claude
+                  <p className="text-foreground opacity-70">
+                    Claude Code 配置文件未找到,请确保已正确安装并配置 Claude
                     Code
                   </p>
                 </CardContent>
@@ -187,7 +187,7 @@ function ClaudeConfigModal({ isOpen, onClose }: ClaudeConfigModalProps) {
                 <CardTitle>说明</CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="text-sm text-foreground/70 space-y-2">
+                <div className="text-sm text-foreground space-y-2">
                   <p>• 此配置信息显示当前 Claude Code 的实际配置内容</p>
                   <p>• 使用 Switch CC 切换供应商会修改此配置文件</p>
                   <p>• 切换后需要重启 Claude Code 终端才能生效</p>

--- a/src/components/MainWindow/ProviderList.tsx
+++ b/src/components/MainWindow/ProviderList.tsx
@@ -41,13 +41,13 @@ function ProviderList({
   if (providerList.length === 0) {
     return (
       <div className="text-center py-12">
-        <div className="text-foreground/40 mb-4">
+        <div className="text-foreground opacity-40 mb-4">
           <Play size={48} className="mx-auto" />
         </div>
         <h3 className="text-lg font-heading text-foreground mb-2">
           还没有供应商配置
         </h3>
-        <p className="text-foreground/60">
+        <p className="text-foreground opacity-70">
           点击上方"添加供应商"按钮开始配置您的第一个 Claude 供应商
         </p>
       </div>
@@ -61,7 +61,7 @@ function ProviderList({
         <div className="relative flex-1">
           <Search
             size={18}
-            className="absolute left-3 top-1/2 transform -translate-y-1/2 text-foreground/50"
+            className="absolute left-3 top-1/2 transform -translate-y-1/2 text-foreground opacity-50"
           />
           <Input
             type="text"
@@ -79,13 +79,13 @@ function ProviderList({
       {/* 列表区域 */}
       {filteredProviders.length === 0 && searchTerm.trim() ? (
         <div className="text-center py-12">
-          <div className="text-foreground/40 mb-4">
+          <div className="text-foreground opacity-40 mb-4">
             <Search size={48} className="mx-auto" />
           </div>
           <h3 className="text-lg font-heading text-foreground mb-2">
             没有找到匹配的供应商
           </h3>
-          <p className="text-foreground/60">
+          <p className="text-foreground opacity-70">
             尝试修改搜索关键词或清空搜索框查看所有供应商
           </p>
         </div>
@@ -129,7 +129,7 @@ function ProviderList({
                       )}
 
                       {provider.createdAt && (
-                        <span className="text-foreground/60">
+                        <span className="text-foreground opacity-70">
                           创建于 {formatTimestamp(provider.createdAt)}
                         </span>
                       )}

--- a/src/components/MainWindow/SettingsModal.tsx
+++ b/src/components/MainWindow/SettingsModal.tsx
@@ -69,7 +69,7 @@ function SettingsModal({ onClose }: SettingsModalProps) {
         <DialogContent>
           <div className="p-6 text-center">
             <div className="w-8 h-8 border-4 border-main border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-            <p>加载设置中...</p>
+            <p className="text-foreground">加载设置中...</p>
           </div>
         </DialogContent>
       </Dialog>
@@ -162,7 +162,7 @@ function SettingsModal({ onClose }: SettingsModalProps) {
                   启用 MenuBar 快捷模式
                 </Label>
               </div>
-              <p className="text-xs text-foreground/60 mt-2 ml-7">
+              <p className="text-xs text-foreground opacity-70 mt-2 ml-7">
                 启用后可通过系统菜单栏快速切换供应商
               </p>
             </CardContent>
@@ -192,7 +192,7 @@ function SettingsModal({ onClose }: SettingsModalProps) {
                   }
                   placeholder="默认使用 ~/.claude"
                 />
-                <p className="text-xs text-foreground/60">
+                <p className="text-xs text-foreground opacity-70">
                   留空使用默认路径 ~/.claude
                 </p>
               </div>
@@ -207,11 +207,11 @@ function SettingsModal({ onClose }: SettingsModalProps) {
             <CardContent>
               <div className="space-y-2 mb-4">
                 <div className="flex justify-between items-center text-sm">
-                  <span className="text-foreground/60">版本：</span>
+                  <span className="text-foreground opacity-70">版本:</span>
                   <Badge variant="neutral">1.0.0</Badge>
                 </div>
                 <div className="flex justify-between items-center text-sm">
-                  <span className="text-foreground/60">构建于：</span>
+                  <span className="text-foreground opacity-70">构建于:</span>
                   <Badge variant="neutral">Tauri 2.8</Badge>
                 </div>
               </div>

--- a/src/components/MenuBar/MenuBarWindow.tsx
+++ b/src/components/MenuBar/MenuBarWindow.tsx
@@ -81,7 +81,7 @@ function MenuBarWindow() {
       <Card className="w-80 shadow-shadow">
         <CardContent className="p-4 text-center">
           <div className="w-6 h-6 border-2 border-main border-t-transparent rounded-full animate-spin mx-auto mb-2"></div>
-          <p className="text-sm text-foreground/60">加载中...</p>
+          <p className="text-sm text-foreground opacity-70">加载中...</p>
         </CardContent>
       </Card>
     );
@@ -147,10 +147,12 @@ function MenuBarWindow() {
       <CardContent className="p-0 max-h-96 overflow-y-auto">
         {providersList.length === 0 ? (
           <div className="p-6 text-center">
-            <div className="text-foreground/40 mb-2">
+            <div className="text-foreground opacity-40 mb-2">
               <Settings size={32} className="mx-auto" />
             </div>
-            <p className="text-sm text-foreground/60 mb-4">还没有配置供应商</p>
+            <p className="text-sm text-foreground opacity-70 mb-4">
+              还没有配置供应商
+            </p>
             <Button onClick={switchToMainWindow} size="sm">
               去添加供应商
             </Button>
@@ -190,7 +192,7 @@ function MenuBarWindow() {
                   {provider.id !== currentProviderId && (
                     <ChevronRight
                       size={16}
-                      className="text-foreground/40 group-hover:text-foreground/60 flex-shrink-0"
+                      className="text-foreground opacity-40 group-hover:opacity-70 flex-shrink-0"
                     />
                   )}
                 </div>
@@ -202,7 +204,7 @@ function MenuBarWindow() {
 
       {/* 底部操作 */}
       <div className="px-4 py-3 bg-secondary-background border-t-2 border-border">
-        <div className="flex items-center justify-between text-xs text-foreground/60">
+        <div className="flex items-center justify-between text-xs text-foreground opacity-70">
           <Badge variant="neutral" className="text-xs">
             {providersList.length} 个供应商
           </Badge>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-base text-sm font-base ring-offset-white transition-all gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-base text-sm font-base ring-offset-white transition-all gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -15,7 +15,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-4 shrink-0 rounded-base border-2 border-border bg-background ring-offset-white focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-main data-[state=checked]:text-main-foreground shadow-shadow",
+        "peer size-4 shrink-0 rounded-base border-2 border-border bg-background ring-offset-white focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-main data-[state=checked]:text-main-foreground shadow-shadow",
         className,
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -64,7 +64,7 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-base opacity-100 ring-offset-white focus:outline-hidden focus:ring-2 focus:ring-black focus:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-base opacity-100 ring-offset-white focus:outline-hidden focus:ring-2 focus:ring-border focus:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <X />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "flex h-10 w-full rounded-base border-2 border-border bg-secondary-background selection:bg-main selection:text-main-foreground px-3 py-2 text-sm font-base text-foreground file:border-0 file:bg-transparent file:text-sm file:font-heading placeholder:text-foreground/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-base border-2 border-border bg-secondary-background selection:bg-main selection:text-main-foreground px-3 py-2 text-sm font-base text-foreground file:border-0 file:bg-transparent file:text-sm file:font-heading placeholder:text-foreground placeholder:opacity-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -14,7 +14,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "text-sm font-heading leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        "text-sm font-heading leading-none text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -34,7 +34,7 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        "flex h-10 w-full items-center justify-between rounded-base border-2 border-border bg-secondary-background gap-2 px-3 py-2 text-sm font-base text-foreground ring-offset-white placeholder:text-foreground/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 focus:outline-hidden focus:ring-2 focus:ring-black focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex h-10 w-full items-center justify-between rounded-base border-2 border-border bg-secondary-background gap-2 px-3 py-2 text-sm font-base text-foreground ring-offset-white placeholder:text-foreground placeholder:opacity-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 focus:outline-hidden focus:ring-2 focus:ring-border focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -126,7 +126,7 @@ function SelectLabel({
     <SelectPrimitive.Label
       data-slot="select-label"
       className={cn(
-        "border-2 border-transparent py-1.5 pr-8 pl-2 text-sm font-base text-foreground/80",
+        "border-2 border-transparent py-1.5 pr-8 pl-2 text-sm font-base text-foreground opacity-80",
         className,
       )}
       {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex min-h-[80px] w-full rounded-base border-2 border-border bg-secondary-background selection:bg-main selection:text-main-foreground px-3 py-2 text-sm font-base text-foreground placeholder:text-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[80px] w-full rounded-base border-2 border-border bg-secondary-background selection:bg-main selection:text-main-foreground px-3 py-2 text-sm font-base text-foreground placeholder:text-foreground placeholder:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}


### PR DESCRIPTION
Replace text-foreground/{opacity} classes with text-foreground + opacity-{value} to ensure better color contrast in dark mode. This change affects:

- ClaudeConfigModal: loading text, config labels, JSON content, empty states
- ProviderList: empty states, search icon, provider timestamps
- SettingsModal: loading text, descriptions, app info labels
- MenuBarWindow: loading text, empty states, chevron icons, footer text
- UI components: input, select, textarea placeholder text

Also update focus ring colors from hardcoded black to theme-aware border color in button, checkbox, dialog, and label components for better dark mode support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)