### PR TITLE
[修复] 修改搜索框聚焦快捷键从 Cmd+/ 为 Ctrl+Shift+/

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -229,9 +229,9 @@ pub fn run() {
 
             let _tray = tray_builder.build(app)?;
 
-            // 注册全局快捷键 Cmd+/
+            // 注册全局快捷键 Ctrl+Shift+/
             {
-                let shortcut: Shortcut = "CmdOrCtrl+/".parse().unwrap();
+                let shortcut: Shortcut = "Ctrl+Shift+/".parse().unwrap();
                 app.global_shortcut()
                     .on_shortcut(shortcut, |app, _shortcut, _event| {
                         if let Some(window) = app.get_webview_window("main") {

--- a/src/components/MainWindow/ProviderList.tsx
+++ b/src/components/MainWindow/ProviderList.tsx
@@ -88,7 +88,7 @@ function ProviderList({
     enableScrollToSelected: true,
   });
 
-  // 监听全局快捷键事件 (Cmd+/)
+  // 监听全局快捷键事件 (Ctrl+Shift+/)
   useEffect(() => {
     const unlisten = listen("focus-search", () => {
       searchInputRef.current?.focus();

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -20,8 +20,8 @@ interface UseKeyboardNavigationProps<T> {
  * @param onSelect - 选中项时的回调函数（按 Enter 时触发）
  * @param currentItemId - 当前激活项的 ID（用于防止重复选择）
  * @param getItemId - 获取项 ID 的函数
- * @param searchInputRef - 搜索框的 ref（用于 "/" 键聚焦）
- * @param enableSlashKey - 是否启用 "/" 键聚焦搜索框（默认 false）
+ * @param searchInputRef - 搜索框的 ref（用于 Ctrl+Shift+/ 键聚焦）
+ * @param enableSlashKey - 是否启用 Ctrl+Shift+/ 键聚焦搜索框（默认 false）
  * @param enableScrollToSelected - 是否启用滚动到选中项（默认 false）
  */
 export function useKeyboardNavigation<T>({
@@ -51,9 +51,11 @@ export function useKeyboardNavigation<T>({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // "/" 键聚焦搜索框
+      // Ctrl+Shift+/ 键聚焦搜索框
       if (
         enableSlashKey &&
+        e.ctrlKey &&
+        e.shiftKey &&
         e.key === "/" &&
         searchInputRef?.current &&
         document.activeElement !== searchInputRef.current


### PR DESCRIPTION
## 变更说明

修改搜索框聚焦快捷键，避免与现有系统快捷键冲突。

- **之前**: `Cmd+/` (CmdOrCtrl+/)
- **之后**: `Ctrl+Shift+/`

## 改动文件

- `src-tauri/src/lib.rs` - Rust 端全局快捷键注册
- `src/hooks/useKeyboardNavigation.ts` - 前端键盘监听逻辑
- `src/components/MainWindow/ProviderList.tsx` - 注释更新